### PR TITLE
fix: correct params handling in room page

### DIFF
--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -50,9 +50,9 @@ type RequestRow = {
 export default function SearchPage({
   params,
 }: {
-  params: Promise<{ code: string }>;
+  params: { code: string };
 }) {
-  const { code } = React.use(params);
+  const { code } = params;
   const [q, setQ] = useState("");
   const [results, setResults] = useState<Video[]>([]);
   const [queue, setQueue] = useState<RequestRow[]>([]);


### PR DESCRIPTION
## Summary
- fix params handling in room page by removing React.use and using direct object

## Testing
- `npm test` (fails: Missing script "test")
- `CI=true npm run lint` (fails: requires ESLint configuration)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a550c1bb0c83209247b860be5e8b97