### PR TITLE
chore: type youtube handlers

### DIFF
--- a/app/room/[code]/player/page.tsx
+++ b/app/room/[code]/player/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import YouTube, { YouTubeProps } from "react-youtube";
 import { Play, Pause, SkipForward, Volume2 } from "lucide-react";
 
@@ -71,10 +71,13 @@ export default function Player({
   const skipToNext = () => {
     onEnd();
   };
-  const onReady: YouTubeProps["onReady"] = (event) => {
-    playerRef.current = event.target;
-    playerRef.current.playVideo();
-  };
+  const onReady = useCallback<NonNullable<YouTubeProps["onReady"]>>(
+    (event) => {
+      playerRef.current = event.target;
+      playerRef.current.playVideo();
+    },
+    []
+  );
   if (!current) {
     return (
       <div className="flex flex-col items-center justify-center h-screen ">


### PR DESCRIPTION
## Summary
- type YouTube player `onReady` handler with `useCallback` for proper event typing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a57423bf1c8320902e7ca5bf20acc1