### PR TITLE
feat: add host controls and now playing info

### DIFF
--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -3,33 +3,10 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import {
-  DndContext,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { Toaster } from "@/components/ui/sonner"; // optional
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { SortableItem } from "@/components/SortableItem";
-import { ColumnDef, useReactTable } from "@tanstack/react-table";
+import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "@/components/data-table";
 import Link from "next/link";
-import { ArrowBigLeft, ArrowRightToLineIcon } from "lucide-react";
+import { ArrowRightToLineIcon } from "lucide-react";
 
 type Video = {
   videoId: string;
@@ -58,7 +35,6 @@ export default function SearchPage({
   const [queue, setQueue] = useState<RequestRow[]>([]);
   const [loadingSearch, setLoadingSearch] = useState(false);
   const [processing, setProcessing] = useState(false);
-  const sensors = useSensors(useSensor(PointerSensor));
   const [loadingId, setLoadingId] = useState<string | null>(null);
 
   const loadQueue = useCallback(async () => {
@@ -145,23 +121,28 @@ export default function SearchPage({
     }
   };
 
+  const nowPlaying = queue[0];
+  const upcoming = queue.slice(1);
+
   const moveUp = (index: number) => {
-    if (index === 0) return;
+    const actualIndex = index + 1;
+    if (actualIndex <= 1) return;
     const newQueue = [...queue];
-    [newQueue[index - 1], newQueue[index]] = [
-      newQueue[index],
-      newQueue[index - 1],
+    [newQueue[actualIndex - 1], newQueue[actualIndex]] = [
+      newQueue[actualIndex],
+      newQueue[actualIndex - 1],
     ];
     setQueue(newQueue);
     updateOrder(newQueue);
   };
 
   const moveDown = (index: number) => {
-    if (index === queue.length - 1) return;
+    const actualIndex = index + 1;
+    if (actualIndex >= queue.length - 1) return;
     const newQueue = [...queue];
-    [newQueue[index], newQueue[index + 1]] = [
-      newQueue[index + 1],
-      newQueue[index],
+    [newQueue[actualIndex], newQueue[actualIndex + 1]] = [
+      newQueue[actualIndex + 1],
+      newQueue[actualIndex],
     ];
     setQueue(newQueue);
     updateOrder(newQueue);
@@ -202,7 +183,7 @@ export default function SearchPage({
           <Button
             size="sm"
             onClick={() => moveDown(row.index)}
-            disabled={row.index === queue.length - 1}
+            disabled={row.index === upcoming.length - 1}
           >
             ↓
           </Button>
@@ -292,9 +273,26 @@ export default function SearchPage({
         ))}
       </div>
 
+      {nowPlaying && (
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Now Playing</h2>
+          <div className="flex items-center gap-4 mb-6">
+            <img
+              src={nowPlaying.thumbnail}
+              alt={nowPlaying.title}
+              className="w-24 h-14 rounded object-cover"
+            />
+            <div>
+              <p className="font-medium">{nowPlaying.title}</p>
+              <p className="text-sm text-muted-foreground">{nowPlaying.channel}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div>
         <h2 className="text-lg font-semibold mb-2">Queue</h2>
-        <DataTable columns={columns} data={queue} />
+        <DataTable columns={columns} data={upcoming} />
       </div>
     </div>
   );

--- a/app/room/[code]/player/page.tsx
+++ b/app/room/[code]/player/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import YouTube, { YouTubeProps } from "react-youtube";
 import { Play, Pause, SkipForward, Volume2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface RequestItem {
   id: string;
@@ -18,9 +19,9 @@ export default function Player({
   params: Promise<{ code: string }>;
 }) {
   const { code } = React.use(params);
-  const [queue, setQueue] = useState<RequestItem[]>([]);
   const [current, setCurrent] = useState<RequestItem | null>(null);
   const playerRef = useRef<any>(null);
+  const [isPaused, setIsPaused] = useState(false);
 
   const loadQueue = async () => {
     try {
@@ -29,9 +30,9 @@ export default function Player({
       });
       if (!res.ok) throw new Error(await res.text());
       const data: RequestItem[] = await res.json();
-      setQueue(data);
       if (data.length > 0) {
         setCurrent(data[0]);
+        setIsPaused(false);
       } else {
         setCurrent(null);
       }
@@ -47,8 +48,8 @@ export default function Player({
       try {
         const data = JSON.parse(e.data);
         if (data.queue) {
-          setQueue(data.queue);
           setCurrent(data.queue[0] || null);
+          setIsPaused(false);
         }
       } catch (err) {
         console.error(err);
@@ -71,9 +72,19 @@ export default function Player({
   const skipToNext = () => {
     onEnd();
   };
+  const togglePause = () => {
+    if (!playerRef.current) return;
+    if (isPaused) {
+      playerRef.current.playVideo();
+    } else {
+      playerRef.current.pauseVideo();
+    }
+    setIsPaused(!isPaused);
+  };
   const onReady: YouTubeProps["onReady"] = (event) => {
     playerRef.current = event.target;
     playerRef.current.playVideo();
+    setIsPaused(false);
   };
   if (!current) {
     return (
@@ -152,6 +163,28 @@ export default function Player({
                 </span>
               </div>
             </div>
+          </div>
+
+          {/* Controls */}
+          <div className="flex items-center gap-4 mt-4">
+            <Button
+              size="icon"
+              variant="secondary"
+              onClick={togglePause}
+            >
+              {isPaused ? (
+                <Play className="w-4 h-4" />
+              ) : (
+                <Pause className="w-4 h-4" />
+              )}
+            </Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              onClick={skipToNext}
+            >
+              <SkipForward className="w-4 h-4" />
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show currently playing track and upcoming queue on room page
- add pause and next controls to host player

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a58641e3dc8320a5c40f653ec5194e